### PR TITLE
Link directly to Discord threads

### DIFF
--- a/src/components/Hit.tsx
+++ b/src/components/Hit.tsx
@@ -7,10 +7,6 @@ type HitProps = {
 };
 
 export default function Hit({ hit }: HitProps) {
-  if (isDiscordHit(hit)) {
-    console.log({ hit });
-  }
-
   return (
     <div className="overflow-hidden rounded-lg border border-neutral-n12 bg-neutral-n11 p-3 shadow">
       {isDocsHit(hit) && (
@@ -52,8 +48,7 @@ export default function Hit({ hit }: HitProps) {
       {isDiscordHit(hit) && (
         <div className="flex flex-col">
           <a
-            // TODO: Link directly to Discord thread?
-            href="https://discord.com/invite/nk6C2qTeCq"
+            href={hit.url}
             className="mb-2 flex items-start gap-2 text-lg font-semibold leading-tight text-discord underline-offset-2 hover:underline"
             target="_blank"
           >

--- a/src/components/types.ts
+++ b/src/components/types.ts
@@ -16,6 +16,7 @@ export type StackHit = BaseHit & {
 
 export type DiscordHit = BaseHit & {
   channel: string;
+  url: string;
   date: number;
   messages: {
     author: {


### PR DESCRIPTION
Uses the new `url` field on a Discord hit to link directly to the thread.

Example link: https://discord.com/channels/1019350475847499849/1111588909365858365

Viewing the thread in Discord:
<img width="1341" alt="image" src="https://github.com/get-convex/convex-resource-search/assets/1382445/de3e3f09-82aa-499c-90c6-4dcbb60c4368">
