### PR TITLE
Replace Snippet with Highlight to show more content, clamp at 2 lines

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@heroicons/react": "^2.0.18",
+        "@tailwindcss/line-clamp": "^0.4.4",
         "@types/node": "20.2.3",
         "@types/react": "18.2.7",
         "@types/react-dom": "18.2.4",
@@ -533,6 +534,14 @@
       "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/line-clamp": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/line-clamp/-/line-clamp-0.4.4.tgz",
+      "integrity": "sha512-5U6SY5z8N42VtrCrKlsTAA35gy2VSyYtHWCsg1H87NU1SXnEfekTVlrga9fzUDrrHcGi2Lb5KenUWb4lRQT5/g==",
+      "peerDependencies": {
+        "tailwindcss": ">=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1"
       }
     },
     "node_modules/@types/dom-speech-recognition": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.0.18",
+    "@tailwindcss/line-clamp": "^0.4.4",
     "@types/node": "20.2.3",
     "@types/react": "18.2.7",
     "@types/react-dom": "18.2.4",

--- a/src/components/Hit.tsx
+++ b/src/components/Hit.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { Snippet } from 'react-instantsearch-hooks-web';
+import { Highlight } from 'react-instantsearch-hooks-web';
 import { SearchHit, isDiscordHit, isDocsHit, isStackHit } from './types';
 
 type HitProps = {
@@ -24,7 +24,11 @@ export default function Hit({ hit }: HitProps) {
             />
             {hit.title}
           </a>
-          <Snippet hit={hit} attribute="contents" className="text-neutral-n5" />
+          <Highlight
+            hit={hit}
+            attribute="contents"
+            className="text-neutral-n5 line-clamp-2"
+          />
         </div>
       )}
       {isStackHit(hit) && (
@@ -42,7 +46,11 @@ export default function Hit({ hit }: HitProps) {
             />
             {hit.title}
           </a>
-          <Snippet hit={hit} attribute="content" className="text-neutral-n5" />
+          <Highlight
+            hit={hit}
+            attribute="content"
+            className="text-neutral-n5 line-clamp-2"
+          />
         </div>
       )}
       {isDiscordHit(hit) && (

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -101,5 +101,6 @@ module.exports = {
         },
       });
     },
+    require('@tailwindcss/line-clamp'),
   ],
 };


### PR DESCRIPTION
Replaces the `Snippet` component with `Highlight`, which allows for displaying the entire contents of a result. The first two lines are shown, providing some more context on the result while still keeping it fairly dense.

Before:

<img width="1612" alt="image" src="https://github.com/get-convex/convex-resource-search/assets/1382445/f4ed4269-0400-4cef-a214-4453f340091e">

After:

<img width="1614" alt="image" src="https://github.com/get-convex/convex-resource-search/assets/1382445/aa750733-499d-4b3a-992c-9987f9d5a48b">
