### PR TITLE
Tabs on smaller screens

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@types/react-dom": "18.2.4",
         "algoliasearch": "^4.17.1",
         "autoprefixer": "10.4.14",
+        "classnames": "^2.3.2",
         "eslint": "8.41.0",
         "eslint-config-next": "13.4.4",
         "next": "13.4.4",
@@ -1176,6 +1177,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/client-only": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/react-dom": "18.2.4",
     "algoliasearch": "^4.17.1",
     "autoprefixer": "10.4.14",
+    "classnames": "^2.3.2",
     "eslint": "8.41.0",
     "eslint-config-next": "13.4.4",
     "next": "13.4.4",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css';
 
 export const metadata = {
   title: 'Convex Developer Search',
-  description: 'Search docs, stack, discord all at once',
+  description: 'Search Docs, Stack, Discord all at once',
 };
 
 export default function RootLayout({

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -31,7 +31,7 @@ export default function Results() {
           <button
             key={name}
             className={classnames(
-              'border-b-2 px-3 py-2 text-xl text-neutral-n5 transition-colors hover:text-neutral-white',
+              'border-b-2 px-3 pb-2 text-xl text-neutral-n5 transition-colors hover:text-neutral-white',
               {
                 'border-transparent': name !== selectedIndexName,
                 'border-neutral-n5 text-neutral-white':

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -1,0 +1,72 @@
+import { Index } from 'react-instantsearch-hooks-web';
+import HitList from './HitList';
+import { useState } from 'react';
+import classnames from 'classnames';
+
+const indexes = [
+  {
+    name: 'docs',
+    title: 'Docs',
+    link: 'https://docs.convex.dev',
+  },
+  {
+    name: 'stack',
+    title: 'Stack',
+    link: 'https://stack.convex.dev',
+  },
+  {
+    name: 'discord',
+    title: 'Discord',
+    link: 'https://discord.com/invite/nk6C2qTeCq',
+  },
+];
+
+export default function Results() {
+  const [selectedIndexName, setSelectedIndexName] = useState(indexes[0].name);
+
+  return (
+    <div className="w-full">
+      <div className="mb-4 flex gap-2 border-b border-neutral-n9 lg:hidden">
+        {indexes.map(({ name, title }) => (
+          <button
+            key={name}
+            className={classnames(
+              'border-b-2 px-3 py-2 text-xl text-neutral-n5 transition-colors hover:text-neutral-white',
+              {
+                'border-transparent': name !== selectedIndexName,
+                'border-neutral-n5 text-neutral-white':
+                  name === selectedIndexName,
+              }
+            )}
+            onClick={() => setSelectedIndexName(name)}
+          >
+            {title}
+          </button>
+        ))}
+      </div>
+      <div className="lg:grid lg:grid-cols-3 lg:gap-6">
+        {indexes.map(({ name, title, link }) => (
+          <div key={name}>
+            <a
+              href={link}
+              className="hidden bg-neutral-n12 py-4 font-display text-xl font-bold leading-none text-neutral-n2 underline-offset-4 shadow-lg stretch-max hover:underline lg:block"
+              target="_blank"
+            >
+              {title}
+            </a>
+            <div
+              className={classnames(
+                { hidden: name !== selectedIndexName },
+                'lg:block'
+              )}
+            >
+              <Index indexName={name}>
+                <HitList />
+              </Index>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -51,7 +51,7 @@ export default function Search() {
   }, []);
 
   return (
-    <div className="flex min-h-screen flex-col gap-6">
+    <div className="flex min-h-screen flex-col gap-4">
       <header className="sticky top-0 z-10 flex h-32 flex-col justify-center gap-4 border-b border-neutral-n10 bg-neutral-n12 px-4 md:h-20 md:flex-row md:items-center md:gap-12">
         <Image src="/logo.svg" alt="Convex logo" width={320} height={36} />
         <SearchBox

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -3,29 +3,11 @@
 import { InformationCircleIcon } from '@heroicons/react/24/outline';
 import Image from 'next/image';
 import { useEffect, useState } from 'react';
-import { Index, useSearchBox } from 'react-instantsearch-hooks-web';
-import HitList from './HitList';
+import { useSearchBox } from 'react-instantsearch-hooks-web';
+import Results from './Results';
 import SearchBox from './SearchBox';
 
 const queryParam = 'q';
-
-const indexes = [
-  {
-    name: 'docs',
-    title: 'Docs',
-    link: 'https://docs.convex.dev',
-  },
-  {
-    name: 'stack',
-    title: 'Stack',
-    link: 'https://stack.convex.dev',
-  },
-  {
-    name: 'discord',
-    title: 'Discord',
-    link: 'https://discord.com/invite/nk6C2qTeCq',
-  },
-];
 
 export default function Search() {
   const { refine } = useSearchBox();
@@ -69,7 +51,7 @@ export default function Search() {
   }, []);
 
   return (
-    <div className="flex min-h-screen flex-col">
+    <div className="flex min-h-screen flex-col gap-6">
       <header className="sticky top-0 z-10 flex h-32 flex-col justify-center gap-4 border-b border-neutral-n10 bg-neutral-n12 px-4 md:h-20 md:flex-row md:items-center md:gap-12">
         <Image src="/logo.svg" alt="Convex logo" width={320} height={36} />
         <SearchBox
@@ -78,35 +60,19 @@ export default function Search() {
           onClear={handleClear}
         />
       </header>
-      {query === '' ? (
-        <div className="flex grow items-center justify-center gap-2 p-4">
-          <InformationCircleIcon className="w-8 shrink-0 text-green-g4" />
-          <span className="text-neutral-n4 md:text-xl">
-            Use the input above to search across Docs, Stack, and Discord.
-          </span>
-        </div>
-      ) : (
-        <main className="flex grow flex-col gap-12 p-4 xl:flex-row xl:gap-6">
-          {indexes.map(({ name, title, link }) => (
-            <div
-              key={name}
-              className="flex grow basis-0 flex-col md:max-w-lg xl:overflow-hidden"
-            >
-              <a
-                href={link}
-                className="sticky top-32 mt-4 bg-neutral-n12 py-4 font-display text-2xl leading-none text-neutral-n2 underline-offset-4 shadow-lg stretch-max hover:underline md:top-2 xl:static xl:mt-0 xl:text-xl xl:font-bold"
-                target="_blank"
-              >
-                {title}
-              </a>
-              <Index indexName={name}>
-                <HitList />
-              </Index>
-            </div>
-          ))}
-        </main>
-      )}
-      <footer className="mt-6 flex flex-col-reverse justify-between gap-4 border-t border-neutral-n10 p-6 sm:flex-row">
+      <main className="flex grow px-4">
+        {query === '' ? (
+          <div className="flex w-full items-center justify-center gap-2">
+            <InformationCircleIcon className="w-8 shrink-0 text-green-g4" />
+            <span className="text-neutral-n4 md:text-xl">
+              Use the input above to search across Docs, Stack, and Discord.
+            </span>
+          </div>
+        ) : (
+          <Results />
+        )}
+      </main>
+      <footer className="flex flex-col-reverse justify-between gap-4 border-t border-neutral-n10 px-4 py-6 sm:flex-row">
         <span className="text-neutral-n4">Copyright © 2023 Convex, Inc.</span>
         <div className="flex gap-4">
           <a


### PR DESCRIPTION
Rather than having Docs, Stack, and Discord all in a single column on smaller screens (under 1024px), this adds tabs to the top for navigating between result sets. This avoids the need for scrolling so much, and makes it more discoverable that we're searching Docs, Stack, and Discord all at once.

## Before

![image](https://github.com/get-convex/convex-resource-search/assets/1382445/c894d818-8d23-4493-aed3-b7da99204541)

## After

![image](https://github.com/get-convex/convex-resource-search/assets/1382445/caa9f7ee-0679-4e99-95fb-4d20883df9e5)
