### PR TITLE
Fix searching via URL param

### DIFF
--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -47,8 +47,11 @@ export default function Search() {
   useEffect(() => {
     const urlParams = new URLSearchParams(window.location.search);
     const searchParam = urlParams.get(queryParam);
-    setQuery(searchParam || '');
-  }, []);
+    if (searchParam) {
+      setQuery(searchParam);
+      refine(searchParam);
+    }
+  }, [refine]);
 
   return (
     <div className="flex min-h-screen flex-col gap-4">


### PR DESCRIPTION
Fixes a bug where the URL param (e.g. `?q=Testing`) was being read and updating the search field as expected, but didn't actually perform the search.

## Before
![image](https://github.com/get-convex/convex-resource-search/assets/1382445/8e176e2b-6f8f-407d-8e63-1f2f01a4e455)

## After
![image](https://github.com/get-convex/convex-resource-search/assets/1382445/ad7eff48-cf27-468c-b5b4-074f393a6916)